### PR TITLE
Possible bug in starting_communities

### DIFF
--- a/packages/pyo3/Cargo.toml
+++ b/packages/pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graspologic_native"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["dwpryce@microsoft.com"]
 edition = "2018"
 license = "MIT"
@@ -8,8 +8,8 @@ description = "Python native companion module to the graspologic library"
 readme = "README.md"
 
 [package.metadata.maturin]
-maintainer = "Dwayne Pryce"
-maintainer-email = "dwpryce@microsoft.com"
+maintainer = "Dax Pryce"
+maintainer-email = "daxpryce@microsoft.com"
 requires-python = ">=3.6,<3.11"
 project-url = {"Github" = "https://github.com/microsoft/graspologic-native", "Graspologic"="https://github.com/microsoft/graspologic"}
 classifier = ["Development Status :: 3 - Alpha", "License :: OSI Approved :: MIT License", "Programming Language :: Python :: Implementation :: CPython", "Programming Language :: Python :: 3.6", "Programming Language :: Python :: 3.7", "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9", "Topic :: Scientific/Engineering :: Mathematics"]

--- a/packages/pyo3/src/lib.rs
+++ b/packages/pyo3/src/lib.rs
@@ -102,9 +102,6 @@ impl PyObjectProtocol for HierarchicalCluster {
 /// :rtype: Dict[str, int]
 /// :raises ClusterIndexingError:
 /// :raises EmptyNetworkError:
-/// :raises InvalidCommunityMappingError: The starting communities dictionary either did not include
-///     a community for each node in the edge list or the edge list did not contain a node present
-///     in the starting community mapping.
 /// :raises InternalNetworkIndexingError: An internal algorithm error. Please report with reproduction steps.
 /// :raises ParameterRangeError: One of the parameters provided did not meet the requirements in the documentation.
 /// :raises UnsafeInducementError: An internal algorithm error. Please report with reproduction steps.
@@ -197,9 +194,6 @@ fn leiden(
 /// :rtype: List[HierarchicalCluster]
 /// :raises ClusterIndexingError:
 /// :raises EmptyNetworkError:
-/// :raises InvalidCommunityMappingError: The starting communities dictionary either did not include
-///     a community for each node in the edge list or the edge list did not contain a node present
-///     in the starting community mapping.
 /// :raises InternalNetworkIndexingError: An internal algorithm error. Please report with reproduction steps.
 /// :raises ParameterRangeError: One of the parameters provided did not meet the requirements in the documentation.
 /// :raises UnsafeInducementError: An internal algorithm error. Please report with reproduction steps.

--- a/packages/pyo3/src/mediator.rs
+++ b/packages/pyo3/src/mediator.rs
@@ -202,7 +202,7 @@ fn communities_to_clustering(
             cluster_mapping.extend(start..end);
             Clustering::as_defined(cluster_mapping, end)
         }
-        None => Clustering.as_self_clusters(network.num_nodes()),
+        None => Clustering::as_self_clusters(network.num_nodes()),
     };
 
     for (node, community) in communities {

--- a/packages/pyo3/src/mediator.rs
+++ b/packages/pyo3/src/mediator.rs
@@ -203,8 +203,8 @@ fn communities_to_clustering(
             let end: usize = start + network.num_nodes();
             cluster_mapping.extend(start..end);
             Clustering::as_defined(cluster_mapping, end)
-        },
-        None => Clustering.as_self_clusters(network.num_nodes())
+        }
+        None => Clustering.as_self_clusters(network.num_nodes()),
     };
 
     let mut all_communities: HashSet<usize> = HashSet::new();

--- a/packages/pyo3/src/mediator.rs
+++ b/packages/pyo3/src/mediator.rs
@@ -209,7 +209,9 @@ fn communities_to_clustering(
         let mapping: Option<CompactNodeId> = network.compact_id_for(node);
         if mapping.is_some() {
             let compact_node_id: CompactNodeId = mapping.unwrap();
-            clustering.update_cluster_at(compact_node_id, community).map_err(|_| PyLeidenError::InvalidCommunityMappingError)?;
+            clustering
+                .update_cluster_at(compact_node_id, community)
+                .map_err(|_| PyLeidenError::ClusterIndexingError)?;
         }
     }
 

--- a/packages/pyo3/src/mediator.rs
+++ b/packages/pyo3/src/mediator.rs
@@ -188,10 +188,8 @@ fn communities_to_clustering(
     network: &LabeledNetwork<String>,
     communities: HashMap<String, usize>,
 ) -> Result<Clustering, PyLeidenError> {
-    // if node not found in internal network, bounce
-    // if max(communities) > len(set(communities)), collapse result
-    // if all nodes are mapped, cool
-    // if not all nodes are mapped, generate integers for each new value
+    // best effort for using a provided community mapping and keeping generated singleton ids
+    // otherwise
 
     let mut clustering: Clustering = match communities.values().max() {
         Some(max_community_id) => {
@@ -207,16 +205,12 @@ fn communities_to_clustering(
         None => Clustering.as_self_clusters(network.num_nodes()),
     };
 
-    let mut all_communities: HashSet<usize> = HashSet::new();
-
     for (node, community) in communities {
-        all_communities.insert(community);
-        let mapped_node: CompactNodeId = network
-            .compact_id_for(node)
-            .ok_or(PyLeidenError::InvalidCommunityMappingError)?;
-        clustering
-            .update_cluster_at(mapped_node, community)
-            .map_err(|_| PyLeidenError::InvalidCommunityMappingError)?;
+        let mapping: Option<CompactNodeId> = network.compact_id_for(node);
+        if mapping.is_some() {
+            let compact_node_id: CompactNodeId = mapping.unwrap();
+            clustering.update_cluster_at(compact_node_id, community).map_err(|_| PyLeidenError::InvalidCommunityMappingError)?;
+        }
     }
 
     // we can't easily know if there are empty clusters, so we'll just presume there are


### PR DESCRIPTION
@JonathanLarson seems to have found a bug that we're pretty sure is in the use of `starting_communities` with Leiden/Hierarchical Leiden.

He's running into an issue where, after providing his own starting communities dictionary, he sometimes gets failures from the native impl where we panic because we saw a subnetwork with 0 members.  Subnetworks are generated based on the ClusterId (aka. community membership unsigned integer, masquerading as a usize), which had me looking into our mapping of python dictionaries into our Clustering object to start things off.

When I first wrote this, I was trying to save every clock cycle, so I tried to incorporate some shortcuts because I thought I had guarded against all possible edge cases, but it turns out that I may have missed some.  Possibly.  I can't repro this, but we'll try with some sane, reasoned fixes and premature-optimization removals and see if we can't rule some stuff out