### PR TITLE
Release 1.1.1

### DIFF
--- a/packages/pyo3/Cargo.toml
+++ b/packages/pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graspologic_native"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["daxpryce@microsoft.com"]
 edition = "2018"
 license = "MIT"

--- a/packages/pyo3/graspologic_native.pyi
+++ b/packages/pyo3/graspologic_native.pyi
@@ -19,7 +19,7 @@ def leiden(
     use_modularity: bool,
     seed: Optional[int],
     trials: int
-) -> Dict[str, int]: ...
+) -> Tuple[float, Dict[str, int]]: ...
 
 def hierarchical_leiden(
     edges: List[Tuple[str, str, float]],

--- a/packages/pyo3/src/lib.rs
+++ b/packages/pyo3/src/lib.rs
@@ -101,7 +101,7 @@ impl HierarchicalCluster {
 ///     clustering.
 /// :return: The modularity of the best community partitioning and a dictionary of node to community
 ///     ids. The community ids will start at 0 and increment.
-/// :rtype: Dict[str, int]
+/// :rtype: Tuple[float, Dict[str, int]]
 /// :raises ClusterIndexingError:
 /// :raises EmptyNetworkError:
 /// :raises InternalNetworkIndexingError: An internal algorithm error. Please report with reproduction steps.


### PR DESCRIPTION
The type hints in stub were added in 1.1.0 and were always wrong, but the actual API is not changing. In other words, we always returned a tuple of float and dict, despite saying we only returned a dictionary.