### PR TITLE
Build with New Deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           maturin-version: latest
           command: build
           target: x64
-          args: -m packages/pyo3/Cargo.toml --release -i ${{env.pythonLocation}}\python.exe --no-sdist
+          args: -m packages/pyo3/Cargo.toml --release -i ${{env.pythonLocation}}\python.exe
 
       - uses: messense/maturin-action@v1
         if: ${{ matrix.os == 'macos-latest' }}
@@ -73,7 +73,7 @@ jobs:
         with:
           maturin-version: latest
           command: build
-          args: -m packages/pyo3/Cargo.toml --release --universal2 --no-sdist
+          args: -m packages/pyo3/Cargo.toml --release --universal2
 
       - uses: messense/maturin-action@v1
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/packages/pyo3/Cargo.toml
+++ b/packages/pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graspologic_native"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["daxpryce@microsoft.com"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
There's a [CVE](https://nvd.nist.gov/vuln/detail/CVE-2020-26235) out for the `time` crate, which `chrono` depends on. Our last build was so long ago that it was built using a version of `time` that had this issue.  

In theory, merely making a new build will rectify this.

In theory.