### PR TITLE
Minor fixes in packaging to make it compatible with maturin 1.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           maturin-version: 1.4.0
           command: build
           target: x64
-          args: -m packages/pyo3/Cargo.toml --release
+          args: -m packages/pyo3/Cargo.toml --release --sdist
           manylinux: 2014
 
       - name: Python Unittests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,16 @@ jobs:
   codestyle-check:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check format
         run: |
           cargo fmt -- --check
   version:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Materialize build number
@@ -21,11 +21,11 @@ jobs:
           pip install -U pip
           pip install toml
           python .github/build/manifest_version.py packages/pyo3/Cargo.toml version.txt
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: cargo-toml
           path: packages/pyo3/Cargo.toml
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: version-txt
           path: version.txt
@@ -37,12 +37,12 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: cargo-toml
           path: materialized
@@ -104,12 +104,12 @@ jobs:
     needs: 'build'
     if: github.ref=='refs/heads/main' || github.ref=='refs/heads/dev'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
@@ -117,7 +117,7 @@ jobs:
         run: |
           sha256sum dist/*.whl > checksums.txt
           cat checksums.txt
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: version-txt
           path: version/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Generate SHA256 files for each wheel
         run: |
           sha256sum dist/*.whl > checksums.txt
+          sha256sum dist/*.tar.gz >> checksums.txt
           cat checksums.txt
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,28 +58,30 @@ jobs:
       # the same steps except for the build, we conditionally do one of the builds depending on the os in question
       # note that windows and mac don't do sdists, but ubuntu does; this is just because we don't need to repeat
       # ourselves or overwrite the .tar.gz sdist.
-      - uses: messense/maturin-action@v1
+
+      - uses: PyO3/maturin-action@v1
         if: ${{ matrix.os == 'windows-latest' }}
         name: Maturin Build for Windows
         with:
-          maturin-version: latest
+          maturin-version: 1.4.0
           command: build
           target: x64
           args: -m packages/pyo3/Cargo.toml --release -i ${{env.pythonLocation}}\python.exe
 
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         if: ${{ matrix.os == 'macos-latest' }}
         name: Maturin Build for MacOS
         with:
-          maturin-version: latest
+          maturin-version: 1.4.0
           command: build
-          args: -m packages/pyo3/Cargo.toml --release --universal2
+          target: universal2-apple-darwin
+          args: -m packages/pyo3/Cargo.toml --release
 
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         if: ${{ matrix.os == 'ubuntu-latest' }}
         name: Maturin Build for Linux
         with:
-          maturin-version: latest
+          maturin-version: 1.4.0
           command: build
           target: x64
           args: -m packages/pyo3/Cargo.toml --release

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git clone git@github.com:microsoft/graspologic-native.git
 cd graspologic-native
 python3.8 -m venv venv
 pip install -U pip setuptools wheel
-pip install pyo3 maturin
+pip install maturin
 cd packages/pyo3
 maturin build --release -i python3.8  # this is where things break on windows.  instead of `python3.8` here, you will need the full path to the correct python.exe on your windows machine, something like `-i "C:\python38\bin\python.exe"`
 ```

--- a/packages/pyo3/Cargo.toml
+++ b/packages/pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graspologic_native"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["daxpryce@microsoft.com"]
 edition = "2018"
 license = "MIT"

--- a/packages/pyo3/Cargo.toml
+++ b/packages/pyo3/Cargo.toml
@@ -7,8 +7,6 @@ license = "MIT"
 description = "Python native companion module to the graspologic library"
 readme = "README.md"
 
-[package.metadata.maturin]
-
 [lib]
 name = "graspologic_native"
 crate-type = ["rlib","cdylib"]

--- a/packages/pyo3/Cargo.toml
+++ b/packages/pyo3/Cargo.toml
@@ -8,11 +8,6 @@ description = "Python native companion module to the graspologic library"
 readme = "README.md"
 
 [package.metadata.maturin]
-maintainer = "Dax Pryce"
-maintainer-email = "daxpryce@microsoft.com"
-requires-python = ">=3.6,<3.12"
-project-url = {"Github" = "https://github.com/microsoft/graspologic-native", "Graspologic"="https://github.com/microsoft/graspologic"}
-classifier = ["Development Status :: 5 - Production/Stable", "License :: OSI Approved :: MIT License", "Programming Language :: Python :: Implementation :: CPython", "Programming Language :: Python :: 3.6", "Programming Language :: Python :: 3.7", "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10", "Programming Language :: Python :: 3.11", "Topic :: Scientific/Engineering :: Mathematics"]
 
 [lib]
 name = "graspologic_native"

--- a/packages/pyo3/README.md
+++ b/packages/pyo3/README.md
@@ -14,7 +14,7 @@ implementation provided at [https://github.com/CWTSLeiden/networkanalysis](https
 was used as a starting point.
 
 ## Releases
-Builds are provided for x86_64 architectures only, for Windows, macOS, and Linux, for Python versions 3.6->3.9.
+Builds are provided for x86_64 architectures only, for Windows, macOS, and Linux, for Python versions 3.6->3.11.
 
 ## Build Tools
 Rust nightly 1.37+ (we are currently using 1.40)

--- a/packages/pyo3/README.md
+++ b/packages/pyo3/README.md
@@ -14,7 +14,7 @@ implementation provided at [https://github.com/CWTSLeiden/networkanalysis](https
 was used as a starting point.
 
 ## Releases
-Builds are provided for x86_64 architectures only, for Windows, macOS, and Linux, for Python versions 3.6->3.11.
+Builds are provided for x86_64 architectures only, for Windows, macOS, and Linux, for Python versions 3.6->3.12.
 
 ## Build Tools
 Rust nightly 1.37+ (we are currently using 1.40)

--- a/packages/pyo3/pyproject.toml
+++ b/packages/pyo3/pyproject.toml
@@ -21,5 +21,5 @@ Graspologic = "https://github.com/microsoft/graspologic"
 
 
 [build-system]
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin"]
 build-backend = "maturin"

--- a/packages/pyo3/pyproject.toml
+++ b/packages/pyo3/pyproject.toml
@@ -1,3 +1,25 @@
+[project]
+name = "graspologic-native"
+maintainer = "Dax Pryce"
+maintainer-email = "daxpryce@microsoft.com"
+requires-python = ">=3.6,<3.12"
+classifier = [
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering :: Mathematics"]
+
+[project.urls]
+Github = "https://github.com/microsoft/graspologic-native"
+Graspologic = "https://github.com/microsoft/graspologic"
+
+
 [build-system]
 requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"

--- a/packages/pyo3/pyproject.toml
+++ b/packages/pyo3/pyproject.toml
@@ -2,7 +2,7 @@
 name = "graspologic-native"
 maintainer = "Dax Pryce"
 maintainer-email = "daxpryce@microsoft.com"
-requires-python = ">=3.6,<3.12"
+requires-python = ">=3.6,<3.13"
 classifier = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
@@ -13,6 +13,7 @@ classifier = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Mathematics"]
 
 [project.urls]

--- a/packages/pyo3/pyproject.toml
+++ b/packages/pyo3/pyproject.toml
@@ -21,5 +21,5 @@ Graspologic = "https://github.com/microsoft/graspologic"
 
 
 [build-system]
-requires = ["maturin"]
+requires = ["maturin>=1.4,<2.0"]
 build-backend = "maturin"


### PR DESCRIPTION
I had some issues when trying to build `graspologic-native`, and the following updates seemed to do the trick to get everything working.

I basically:
 - reorganized the metadata a bit
 - relaxed the maturin requierment
 - update the install instructions
 - updated supported python versions in the README to match what is mentioned in the "classifier" section

Thank you for providing such a nice package!
